### PR TITLE
Fix notifications disable crash on web

### DIFF
--- a/lib/notifService.js
+++ b/lib/notifService.js
@@ -1,5 +1,6 @@
 import * as Notifications from 'expo-notifications';
 import * as Device from 'expo-device';
+import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import QuoteService from './quoteService';
 
@@ -42,7 +43,9 @@ export default {
   },
 
   async disable() {
-    await Notifications.cancelAllScheduledNotificationsAsync();
+    if (Platform.OS !== 'web') {
+      await Notifications.cancelAllScheduledNotificationsAsync();
+    }
     await AsyncStorage.setItem('prefs', JSON.stringify({ enabled: false }));
   },
 };


### PR DESCRIPTION
## Summary
- check for `Platform.OS` before calling `cancelAllScheduledNotificationsAsync`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ef4c42788323a31168b1b7584791