### PR TITLE
Improve theme support and quote display

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -8,6 +8,7 @@ type Quote = {
   id: string | number;
   citation: string;
   auteur: string;
+  date_creation: string;
 };
 
 export default function Home() {
@@ -58,28 +59,29 @@ export default function Home() {
           <ActivityIndicator color={colors.primary} />
         ) : (
           <>
+            <Text style={[styles.author, { color: colors.text }]}>{quote.auteur}</Text>
+            <Text style={[styles.date, { color: colors.text }]}>{quote.date_creation}</Text>
             <Text style={[styles.quote, { color: colors.text }]}>“{quote.citation}”</Text>
-            <Text style={[styles.author, { color: colors.text }]}>— {quote.auteur}</Text>
           </>
         )}
       </View>
 
       <View style={styles.buttons}>
-        <Pressable
-          style={[styles.btn, { backgroundColor: colors.primary }]}
-          onPress={loadRandom}
-        >
-          <Text style={styles.btnText}>Nouvelle citation</Text>
-        </Pressable>
-
         {daily && quote.id !== daily.id && (
           <Pressable
             onPress={loadDaily}
-            style={[styles.btn, { backgroundColor: colors.primary, marginTop: 8 }]}
+            style={[styles.btn, { backgroundColor: colors.primary }]}
           >
             <Text style={styles.btnText}>Revenir à la citation du jour</Text>
           </Pressable>
         )}
+
+        <Pressable
+          style={[styles.btn, { backgroundColor: colors.primary, marginTop: 8 }]}
+          onPress={loadRandom}
+        >
+          <Text style={styles.btnText}>Nouvelle citation</Text>
+        </Pressable>
       </View>
     </View>
   );
@@ -90,9 +92,10 @@ const styles = StyleSheet.create({
   container: { flex: 1, padding: 24, justifyContent: 'center', alignItems: 'center' },
   settings: { position: 'absolute', top: 48, right: 24 },
   icon: { fontSize: 22 },
-  card: { marginBottom: 32 },
-  quote: { fontSize: 22, fontStyle: 'italic', textAlign: 'center' },
-  author: { fontSize: 16, textAlign: 'center', marginTop: 12 },
+  card: { marginBottom: 32, alignItems: 'center' },
+  quote: { fontSize: 22, fontStyle: 'italic', textAlign: 'center', marginTop: 12 },
+  author: { fontSize: 16, textAlign: 'center' },
+  date: { fontSize: 14, textAlign: 'center', marginTop: 4 },
   buttons: {
     position: 'absolute',
     bottom: 100,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -9,10 +9,10 @@ import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
-import { ThemeProvider } from '../lib/theme';
+import { ThemeProvider, useTheme } from '../lib/theme';
 
 export default function RootLayout() {
-  const colorScheme = useColorScheme();
+  const systemScheme = useColorScheme();
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
@@ -23,16 +23,22 @@ export default function RootLayout() {
   }
 
   return (
-    <NavigationThemeProvider
-      value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}
-    >
-      <ThemeProvider scheme={colorScheme ?? 'light'}>
-        <Stack>
-          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          <Stack.Screen name="+not-found" />
-        </Stack>
-        <StatusBar style="auto" />
-      </ThemeProvider>
+    <ThemeProvider scheme={systemScheme ?? 'light'}>
+      <NavigationContainer />
+    </ThemeProvider>
+  );
+}
+
+function NavigationContainer() {
+  const { mode } = useTheme();
+
+  return (
+    <NavigationThemeProvider value={mode === 'dark' ? DarkTheme : DefaultTheme}>
+      <Stack>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="+not-found" />
+      </Stack>
+      <StatusBar style="auto" />
     </NavigationThemeProvider>
   );
 }

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -22,6 +22,7 @@ export function ThemeProvider({ children, scheme }) {
   const value = useMemo(
     () => ({
       colors,
+      mode,
       label: mode === 'system' ? 'Système' : mode === 'dark' ? 'Sombre' : 'Clair',
       nextScheme: () =>
         setMode((m) =>


### PR DESCRIPTION
## Summary
- sync navigation and theme context to fix light mode
- display quote author, date, then text
- swap daily quote and random quote buttons

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474391b1288323a74fa8955088520b