### PR TITLE
Mise à jour interface thème et affichage

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -59,9 +59,9 @@ export default function Home() {
           <ActivityIndicator color={colors.primary} />
         ) : (
           <>
-            <Text style={[styles.author, { color: colors.text }]}>{quote.auteur}</Text>
-            <Text style={[styles.date, { color: colors.text }]}>{quote.date_creation}</Text>
             <Text style={[styles.quote, { color: colors.text }]}>“{quote.citation}”</Text>
+            <Text style={[styles.date, { color: colors.text }]}>{quote.date_creation}</Text>
+            <Text style={[styles.author, { color: colors.text }]}>{quote.auteur}</Text>
           </>
         )}
       </View>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -38,7 +38,7 @@ function NavigationContainer() {
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>
-      <StatusBar style="auto" />
+      <StatusBar style={mode === 'dark' ? 'light' : 'dark'} />
     </NavigationThemeProvider>
   );
 }

--- a/app/settings.js
+++ b/app/settings.js
@@ -1,13 +1,13 @@
 import { useState, useEffect } from 'react';
-import { View, Text, Pressable, Switch, StyleSheet, Platform } from 'react-native';
-import { router } from 'expo-router';
+import { View, Text, Switch, StyleSheet, Platform } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
 import * as Notifications from 'expo-notifications';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useTheme } from '../lib/theme';
 import NotifService from '../lib/notifService';
 
 export default function Settings() {
-  const { colors, nextScheme, label } = useTheme();
+  const { colors, mode, setScheme } = useTheme();
   const [enabled, setEnabled] = useState(true);
   const [hour, setHour] = useState({ h: 10, m: 0 });
 
@@ -38,9 +38,6 @@ export default function Settings() {
 
   return (
     <View style={[styles.container, { backgroundColor: colors.bg }]}>
-      <Pressable onPress={router.back} style={styles.back}>
-        <Text style={[styles.icon, { color: colors.primary }]}>←</Text>
-      </Pressable>
 
       <Text style={[styles.h1, { color: colors.text }]}>Paramètres</Text>
 
@@ -49,21 +46,26 @@ export default function Settings() {
         <Switch value={enabled} onValueChange={toggleNotif} />
       </View>
 
-      <View style={styles.row}>
-        <Text style={[styles.label, { color: colors.text }]}>Thème&nbsp;: {label}</Text>
-        <Pressable onPress={nextScheme}>
-          <Text style={{ color: colors.primary }}>Changer</Text>
-        </Pressable>
-      </View>
+        <View style={styles.row}>
+          <Text style={[styles.label, { color: colors.text }]}>Thème</Text>
+          <Picker
+            selectedValue={mode}
+            style={[styles.picker, { color: colors.text }]}
+            onValueChange={setScheme}
+            dropdownIconColor={colors.text}
+          >
+            <Picker.Item label="Clair" value="light" />
+            <Picker.Item label="Sombre" value="dark" />
+          </Picker>
+        </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1, padding: 24, paddingTop: 72 },
-  back: { position: 'absolute', top: 40, left: 24 },
-  icon: { fontSize: 24 },
   h1: { fontSize: 24, fontWeight: '700', marginBottom: 32 },
   row: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 },
   label: { fontSize: 16 },
+  picker: { height: 32, width: 120 },
 });

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -17,17 +17,21 @@ const ThemeCtx = createContext();
 export function ThemeProvider({ children, scheme }) {
   const [mode, setMode] = useState(scheme); // 'light' | 'dark' | 'system'
 
-  const colors = mode === 'dark' ? Dark : Light;
+  const isDark =
+    mode === 'dark' || (mode === 'system' && Appearance.getColorScheme() === 'dark');
+  const colors = isDark ? Dark : Light;
 
   const value = useMemo(
     () => ({
       colors,
       mode,
-      label: mode === 'system' ? 'Système' : mode === 'dark' ? 'Sombre' : 'Clair',
+      label:
+        mode === 'system' ? 'Système' : mode === 'dark' ? 'Sombre' : 'Clair',
       nextScheme: () =>
         setMode((m) =>
           m === 'light' ? 'dark' : m === 'dark' ? 'system' : 'light'
         ),
+      setScheme: setMode,
     }),
     [mode]
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
         "@react-native-async-storage/async-storage": "2.1.2",
+        "@react-native-picker/picker": "^2.4.8",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
@@ -2822,6 +2823,19 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-picker/picker": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.11.0.tgz",
+      "integrity": "sha512-QuZU6gbxmOID5zZgd/H90NgBnbJ3VV6qVzp6c7/dDrmWdX8S0X5YFYgDcQFjE3dRen9wB9FWnj2VVdPU64adSg==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
-    "expo-device": "~7.1.4"
+    "expo-device": "~7.1.4",
+    "@react-native-picker/picker": "^2.4.8"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Résumé
- remplacé la sélection de thème par un menu déroulant
- ajusté le ThemeProvider pour exposer `setScheme` et détecter correctement le mode
- appliqué la couleur du statut bar suivant le thème
- réordonné la citation sur l'accueil
- retiré le bouton retour des paramètres
- ajout de `@react-native-picker/picker`

## Tests
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68474627544483239a479f75a2465dd6