### PR TITLE
Fix documentation for missing picker module

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
 
 1. Install dependencies
 
+   Install the picker library used in the settings screen:
+
    ```bash
    npm install
+   npx expo install @react-native-picker/picker
    ```
 
 2. Start the app


### PR DESCRIPTION
## Summary
- clarify that `@react-native-picker/picker` needs installation

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475528ae7c832381e57c5548e4e57f