### PR TITLE
Update UI colors and settings info

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -60,7 +60,9 @@ export default function Home() {
         ) : (
           <>
             <Text style={[styles.quote, { color: colors.text }]}>“{quote.citation}”</Text>
-            <Text style={[styles.date, { color: colors.text }]}>{quote.date_creation}</Text>
+            <Text style={[styles.date, { color: colors.text }]}>
+              {new Date(quote.date_creation).getFullYear()}
+            </Text>
             <Text style={[styles.author, { color: colors.text }]}>{quote.auteur}</Text>
           </>
         )}
@@ -68,16 +70,13 @@ export default function Home() {
 
       <View style={styles.buttons}>
         {daily && quote.id !== daily.id && (
-          <Pressable
-            onPress={loadDaily}
-            style={[styles.btn, { backgroundColor: colors.primary }]}
-          >
+          <Pressable onPress={loadDaily} style={[styles.btn, { backgroundColor: '#fff' }]}>
             <Text style={styles.btnText}>Revenir à la citation du jour</Text>
           </Pressable>
         )}
 
         <Pressable
-          style={[styles.btn, { backgroundColor: colors.primary, marginTop: 8 }]}
+          style={[styles.btn, { backgroundColor: '#fff', marginTop: 8 }]}
           onPress={loadRandom}
         >
           <Text style={styles.btnText}>Citation aléatoire</Text>
@@ -104,5 +103,5 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   btn: { paddingVertical: 12, paddingHorizontal: 24, borderRadius: 8, alignSelf: 'center' },
-  btnText: { color: '#fff', fontWeight: '600', fontSize: 18 },
+  btnText: { color: '#000', fontWeight: '600', fontSize: 18 },
 });

--- a/app/settings.js
+++ b/app/settings.js
@@ -4,6 +4,7 @@ import { Picker } from '@react-native-picker/picker';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useTheme } from '../lib/theme';
 import NotifService from '../lib/notifService';
+import { ExternalLink } from '@/components/ExternalLink';
 
 export default function Settings() {
   const { colors } = useTheme();
@@ -57,6 +58,12 @@ export default function Settings() {
           ))}
         </Picker>
       </View>
+
+      <Text style={[styles.credit, { color: colors.text }]}>Application créée par{' '}
+        <ExternalLink href="https://quvntvn.netlify.app/">
+          <Text style={[styles.link, { color: colors.primary }]}>Quvntvn</Text>
+        </ExternalLink>
+      </Text>
     </View>
   );
 }
@@ -67,4 +74,6 @@ const styles = StyleSheet.create({
   row: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 },
   label: { fontSize: 16 },
   picker: { height: 32, width: 120 },
+  credit: { marginTop: 32, textAlign: 'center', fontSize: 14 },
+  link: { textDecorationLine: 'underline' },
 });


### PR DESCRIPTION
## Summary
- update quote date to display only year
- use white background and black text for action buttons
- mention Quvntvn as the app creator with portfolio link in Settings

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847de36c190832393d701d88bcd5114